### PR TITLE
字典数据关键字检索 不起作用

### DIFF
--- a/src/api/system/dict/types.ts
+++ b/src/api/system/dict/types.ts
@@ -72,7 +72,8 @@ export interface DictQuery extends PageQuery {
   /**
    * 字典项名称
    */
-  name?: string;
+  // name?: string;
+  keywords?: string;
   /**
    * 字典类型编码
    */

--- a/src/views/system/dict/DictData.vue
+++ b/src/views/system/dict/DictData.vue
@@ -202,7 +202,7 @@ onMounted(() => {
       <el-form ref="queryFormRef" :model="queryParams" :inline="true">
         <el-form-item label="关键字" prop="name">
           <el-input
-            v-model="queryParams.name"
+            v-model="queryParams.keywords"
             placeholder="字典名称"
             clearable
           />


### PR DESCRIPTION
输入关键字，按检索 没有对表中的数据进行过滤。
给后端传的 参数 不对。name -> keywords